### PR TITLE
[Feat] 이달의리그, 다른사람 기록 조회 API 관련 #32

### DIFF
--- a/src/main/java/clpetition/backend/global/infra/docs/SwaggerConfig.java
+++ b/src/main/java/clpetition/backend/global/infra/docs/SwaggerConfig.java
@@ -18,7 +18,7 @@ import java.util.Arrays;
         info = @Info(
                 title = "Clpetition API Docs",
                 description = "클피티션 API 명세서",
-                version = "v0.4.0"
+                version = "v0.5.0"
         )
 )
 @Configuration

--- a/src/main/java/clpetition/backend/league/controller/MainLeagueController.java
+++ b/src/main/java/clpetition/backend/league/controller/MainLeagueController.java
@@ -1,0 +1,33 @@
+package clpetition.backend.league.controller;
+
+import clpetition.backend.global.annotation.FindMember;
+import clpetition.backend.global.response.BaseResponse;
+import clpetition.backend.league.docs.GetMainLeagueApiDocs;
+import clpetition.backend.league.dto.response.GetMainLeagueResponse;
+import clpetition.backend.league.service.LeagueService;
+import clpetition.backend.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@PreAuthorize("hasRole('USER')")
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/main")
+public class MainLeagueController implements
+        GetMainLeagueApiDocs {
+
+    private final LeagueService leagueService;
+
+    @GetMapping("/league")
+    public ResponseEntity<BaseResponse<GetMainLeagueResponse>> getMainLeague(
+            @FindMember Member member
+    ) {
+        return BaseResponse.toResponseEntityContainsResult(leagueService.getMainLeague(member));
+    }
+}

--- a/src/main/java/clpetition/backend/league/docs/GetMainLeagueApiDocs.java
+++ b/src/main/java/clpetition/backend/league/docs/GetMainLeagueApiDocs.java
@@ -1,0 +1,27 @@
+package clpetition.backend.league.docs;
+
+import clpetition.backend.global.annotation.FindMember;
+import clpetition.backend.global.response.BaseResponse;
+import clpetition.backend.league.dto.response.GetMainLeagueResponse;
+import clpetition.backend.member.domain.Member;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Main API", description = "홈 화면 API")
+public interface GetMainLeagueApiDocs {
+
+    @Operation(summary = "홈 이달의리그 정보 조회 API", description = "홈 화면의 이달의리그 관련 정보를 조회합니다.")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "🟢 정상"),
+            }
+    )
+    ResponseEntity<BaseResponse<GetMainLeagueResponse>> getMainLeague(
+            @Parameter(hidden = true)
+            @FindMember Member member
+    );
+}

--- a/src/main/java/clpetition/backend/league/docs/dto/response/GetMainLeagueResponseSchema.java
+++ b/src/main/java/clpetition/backend/league/docs/dto/response/GetMainLeagueResponseSchema.java
@@ -1,0 +1,19 @@
+package clpetition.backend.league.docs.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "홈 이달의리그 정보 조회 응답")
+public interface GetMainLeagueResponseSchema {
+
+    @Schema(description = "참여한 난이도", example = "주황", nullable = true)
+    String difficulty();
+
+    @Schema(description = "순위", example = "17", nullable = true)
+    Integer rank();
+
+    @Schema(description = "완등 수", example = "55", nullable = true)
+    Integer totalSend();
+
+    @Schema(description = "전월 대비 순위 차이 (음수일 경우, 전월 대비 떨어진 것을 의미)", example = "6", nullable = true)
+    Integer gapRecentMonth();
+}

--- a/src/main/java/clpetition/backend/league/dto/response/GetMainLeagueResponse.java
+++ b/src/main/java/clpetition/backend/league/dto/response/GetMainLeagueResponse.java
@@ -1,0 +1,13 @@
+package clpetition.backend.league.dto.response;
+
+import clpetition.backend.league.docs.dto.response.GetMainLeagueResponseSchema;
+import lombok.Builder;
+
+@Builder
+public record GetMainLeagueResponse(
+        String difficulty,
+        Integer rank,
+        Integer totalSend,
+        Integer gapRecentMonth
+) implements GetMainLeagueResponseSchema {
+}

--- a/src/main/java/clpetition/backend/league/repository/LeagueQueryRepository.java
+++ b/src/main/java/clpetition/backend/league/repository/LeagueQueryRepository.java
@@ -6,8 +6,11 @@ import clpetition.backend.league.dto.response.GetLeagueRankResponse;
 import clpetition.backend.member.domain.Member;
 
 import java.util.List;
+import java.util.Map;
 
 public interface LeagueQueryRepository {
     List<GetLeagueRankResponse> getLeagueRankTopFifty(Integer season, Difficulty difficulty);
     GetLeagueRankMemberResponse getLeagueRankMember(Member member, Integer season, Difficulty difficulty);
+    Integer getLeagueRank(Member member, Integer season, Difficulty difficulty);
+    Map<String, Integer> getLeagueRankAndTotalSend(Member member, Integer season, Difficulty difficulty);
 }

--- a/src/main/java/clpetition/backend/league/repository/LeagueRepository.java
+++ b/src/main/java/clpetition/backend/league/repository/LeagueRepository.java
@@ -1,10 +1,15 @@
 package clpetition.backend.league.repository;
 
+import clpetition.backend.gym.domain.Difficulty;
 import clpetition.backend.league.domain.League;
 import clpetition.backend.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface LeagueRepository extends JpaRepository<League, Long>, LeagueQueryRepository {
     void deleteByMemberAndSeason(Member member, Integer season);
     boolean existsByMemberAndSeason(Member member, Integer season);
+    boolean existsByMemberAndSeasonAndDifficulty(Member member, Integer season, Difficulty difficulty);
+    Optional<League> findByMemberAndSeason(Member member, Integer season);
 }

--- a/src/main/java/clpetition/backend/league/service/LeagueService.java
+++ b/src/main/java/clpetition/backend/league/service/LeagueService.java
@@ -6,6 +6,7 @@ import clpetition.backend.gym.domain.Difficulty;
 import clpetition.backend.league.domain.League;
 import clpetition.backend.league.dto.response.GetLeagueRankMemberResponse;
 import clpetition.backend.league.dto.response.GetLeagueRankResponse;
+import clpetition.backend.league.dto.response.GetMainLeagueResponse;
 import clpetition.backend.league.repository.LeagueRepository;
 import clpetition.backend.member.domain.Member;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static clpetition.backend.league.domain.League.SEASON;
 
@@ -50,7 +53,43 @@ public class LeagueService {
      * 리그 사용자 순위 조회
      * */
     public GetLeagueRankMemberResponse getLeagueRankMember(Member member, String difficulty) {
+        isExist(member, Difficulty.findByKey(difficulty));
         return toGetLeagueRankMemberResponse(member, Difficulty.findByKey(difficulty));
+    }
+
+    /**
+     * 리그 사용자 간략한 정보 조회 (선택 난이도, 순위)
+     * */
+    public Map<String, Object> getLeagueBrief(Member member) {
+        Optional<League> league = getLeague(member, SEASON);
+
+        if (league.isEmpty())
+            return Map.of("difficulty", Optional.empty(), "rank", Optional.empty());
+
+        Difficulty difficulty = league.get().getDifficulty();
+        Integer rank = getLeagueRank(member, SEASON, difficulty);
+
+        return Map.of("difficulty", difficulty.getKey(), "rank", rank);
+    }
+
+    /**
+     * 홈 이달의리그 정보 조회
+     * */
+    public GetMainLeagueResponse getMainLeague(Member member) {
+        Optional<League> league = getLeague(member, SEASON);
+        Optional<League> recentLeague = getLeague(member, SEASON - 1);
+
+        if (league.isEmpty())
+            return GetMainLeagueResponse.builder().build();
+
+        Difficulty difficulty = league.get().getDifficulty();
+        Map<String, Integer> rankAndTotalSend = getLeagueRankAndTotalSend(member, difficulty);
+
+        if (recentLeague.isEmpty())
+            return toGetMainLeagueResponse(difficulty, rankAndTotalSend, null);
+        Integer recentRank = getLeagueRank(member, SEASON - 1, difficulty);
+
+        return toGetMainLeagueResponse(difficulty, rankAndTotalSend, recentRank - rankAndTotalSend.get("rank"));
     }
 
     /**
@@ -76,8 +115,16 @@ public class LeagueService {
      * 이미 리그에 추가되어 있는 상태에서는 추가 금지
      * */
     private void isAlreadyExist(Member member) {
-        if(leagueRepository.existsByMemberAndSeason(member, SEASON))
+        if (leagueRepository.existsByMemberAndSeason(member, SEASON))
             throw new BaseException(BaseResponseStatus.LEAGUE_ALREADY_REGISTERED_ERROR);
+    }
+
+    /**
+     * 탐색할 리그에 사용자가 존재하지 않을 시 예외
+     * */
+    private void isExist(Member member, Difficulty difficulty) {
+        if (!leagueRepository.existsByMemberAndSeasonAndDifficulty(member, SEASON, difficulty))
+            throw new BaseException(BaseResponseStatus.LEAGUE_MEMBER_NOT_FOUND_ERROR);
     }
 
     /**
@@ -92,5 +139,38 @@ public class LeagueService {
      * */
     private GetLeagueRankMemberResponse toGetLeagueRankMemberResponse(Member member, Difficulty difficulty) {
         return leagueRepository.getLeagueRankMember(member, SEASON, difficulty);
+    }
+
+    /**
+     * 사용자가 등록된 리그 조회 (난이도)
+     * */
+    private Optional<League> getLeague(Member member, Integer season) {
+        return leagueRepository.findByMemberAndSeason(member, season);
+    }
+
+    /**
+     * 리그 사용자 간략한 정보 조회 (순위)
+     * */
+    private Integer getLeagueRank(Member member, Integer season, Difficulty difficulty) {
+        return leagueRepository.getLeagueRank(member, season, difficulty);
+    }
+
+    /**
+     * 홈 이달의리그 정보 조회 (순위, 완등 수)
+     * */
+    private Map<String, Integer> getLeagueRankAndTotalSend(Member member, Difficulty difficulty) {
+        return leagueRepository.getLeagueRankAndTotalSend(member, SEASON, difficulty);
+    }
+
+    /**
+     * 홈 이달의리그 정보 조회 to dto
+     * */
+    private GetMainLeagueResponse toGetMainLeagueResponse(Difficulty difficulty, Map<String, Integer> rankAndTotalSend, Integer gapRecentMonth) {
+        return GetMainLeagueResponse.builder()
+                .difficulty(difficulty.getKey())
+                .rank(rankAndTotalSend.get("rank"))
+                .totalSend(rankAndTotalSend.get("totalSend"))
+                .gapRecentMonth(gapRecentMonth)
+                .build();
     }
 }

--- a/src/main/java/clpetition/backend/member/docs/dto/response/GetProfileResponseSchema.java
+++ b/src/main/java/clpetition/backend/member/docs/dto/response/GetProfileResponseSchema.java
@@ -45,4 +45,10 @@ public interface GetProfileResponseSchema {
 
     @Schema(description = "초대 코드", example = "wvKvv")
     String inviteCode();
+
+    @Schema(description = "리그 난이도", example = "주황", nullable = true)
+    String difficulty();
+
+    @Schema(description = "리그 순위", example = "17", nullable = true)
+    Integer rank();
 }

--- a/src/main/java/clpetition/backend/member/dto/response/GetProfileResponse.java
+++ b/src/main/java/clpetition/backend/member/dto/response/GetProfileResponse.java
@@ -19,6 +19,8 @@ public record GetProfileResponse(
         Long totalRecord,
         LocalDate birthDate,
         String gender,
-        String inviteCode
+        String inviteCode,
+        String difficulty,
+        Integer rank
 ) implements GetProfileResponseSchema {
 }

--- a/src/main/java/clpetition/backend/record/controller/RecordController.java
+++ b/src/main/java/clpetition/backend/record/controller/RecordController.java
@@ -56,7 +56,7 @@ public class RecordController implements
             @PathVariable("recordId") Long recordId
     ) {
         return BaseResponse.toResponseEntityContainsResult
-                (recordService.getRecordDetails(member, recordId));
+                (recordService.getRecordDetails(recordId));
     }
 
     @PutMapping(value = "/{recordId}")

--- a/src/main/java/clpetition/backend/record/controller/RecordController.java
+++ b/src/main/java/clpetition/backend/record/controller/RecordController.java
@@ -56,7 +56,7 @@ public class RecordController implements
             @PathVariable("recordId") Long recordId
     ) {
         return BaseResponse.toResponseEntityContainsResult
-                (recordService.getRecordDetails(recordId));
+                (recordService.getRecordDetails(member, recordId));
     }
 
     @PutMapping(value = "/{recordId}")

--- a/src/main/java/clpetition/backend/record/docs/GetRecordDetailsApiDocs.java
+++ b/src/main/java/clpetition/backend/record/docs/GetRecordDetailsApiDocs.java
@@ -24,7 +24,7 @@ public interface GetRecordDetailsApiDocs {
             value = {
                     @ApiResponse(responseCode = "200", description = "🟢 정상"),
                     @ApiResponse(
-                            responseCode = "404", description = "❌ 입력받은 등반 기록 ID가 DB에 존재하지 않거나, 현재 사용자의 등반 기록이 아님",
+                            responseCode = "404", description = "❌ 입력받은 등반 기록 ID가 DB에 존재하지 않음",
                             content = @Content(
                                     mediaType = MediaType.APPLICATION_JSON_VALUE,
                                     schema = @Schema(implementation = BaseResponse.class),

--- a/src/main/java/clpetition/backend/record/docs/GetRecordDetailsApiDocs.java
+++ b/src/main/java/clpetition/backend/record/docs/GetRecordDetailsApiDocs.java
@@ -24,7 +24,7 @@ public interface GetRecordDetailsApiDocs {
             value = {
                     @ApiResponse(responseCode = "200", description = "🟢 정상"),
                     @ApiResponse(
-                            responseCode = "404", description = "❌ 입력받은 등반 기록 ID가 DB에 존재하지 않음",
+                            responseCode = "404", description = "❌ 입력받은 등반 기록 ID가 DB에 존재하지 않거나, 타인의 private 등반 기록을 조회하려고 시도",
                             content = @Content(
                                     mediaType = MediaType.APPLICATION_JSON_VALUE,
                                     schema = @Schema(implementation = BaseResponse.class),

--- a/src/main/java/clpetition/backend/record/docs/dto/response/GetRecordDetailsResponseSchema.java
+++ b/src/main/java/clpetition/backend/record/docs/dto/response/GetRecordDetailsResponseSchema.java
@@ -12,16 +12,16 @@ import java.util.Map;
 public interface GetRecordDetailsResponseSchema {
 
     @Schema(description = "등반 기록 ID", example = "3")
-    Long getRecordId();
+    Long recordId();
 
     @Schema(description = "암장 정보")
-    GetGymDetailsResponse getGym();
+    GetGymDetailsResponse gym();
 
     @Schema(description = "기록 날짜", example = "2024-08-09")
-    LocalDate getDate();
+    LocalDate date();
 
     @Schema(description = "기록 요일", example = "5")
-    Integer getWeekday();
+    Integer weekday();
 
     @Schema(description = "난이도 정보", example = """
                                                 {
@@ -29,19 +29,19 @@ public interface GetRecordDetailsResponseSchema {
                                                     "초록": 1
                                                 }
                                                 """)
-    Map<String, Integer> getDifficulties();
+    Map<String, Integer> difficulties();
 
     @Schema(description = "메모", example = "기록 저장 테스트", nullable = true)
-    String getMemo();
+    String memo();
 
     @Schema(description = "운동 시간", example = "01:30")
-    LocalTime getExerciseTime();
+    LocalTime exerciseTime();
 
     @Schema(description = "만족도", example = "4")
-    Integer getSatisfaction();
+    Integer satisfaction();
 
     @Schema(description = "비공개 여부", example = "true")
-    Boolean getIsPrivate();
+    Boolean isPrivate();
 
     @Schema(description = "첨부 이미지 URL 목록", example = """
                                                         [
@@ -49,5 +49,20 @@ public interface GetRecordDetailsResponseSchema {
                                                             "url2"
                                                         ]
                                                         """)
-    List<String> getImageUrls();
+    List<String> imageUrls();
+
+    @Schema(description = "사용자 ID", example = "2", nullable = true)
+    Long memberId();
+
+    @Schema(description = "프로필 사진 URL", example = "url", nullable = true)
+    String profileImageUrl();
+
+    @Schema(description = "닉네임", example = "위즈", nullable = true)
+    String nickname();
+
+    @Schema(description = "리그 참여 난이도", example = "주황", nullable = true)
+    String difficulty();
+
+    @Schema(description = "리그 순위", example = "17", nullable = true)
+    Integer rank();
 }

--- a/src/main/java/clpetition/backend/record/docs/dto/response/GetRecordDetailsResponseSchema.java
+++ b/src/main/java/clpetition/backend/record/docs/dto/response/GetRecordDetailsResponseSchema.java
@@ -51,18 +51,18 @@ public interface GetRecordDetailsResponseSchema {
                                                         """)
     List<String> imageUrls();
 
-    @Schema(description = "사용자 ID", example = "2", nullable = true)
+    @Schema(description = "사용자 ID(다른 사람 기록일 때)", example = "2", nullable = true)
     Long memberId();
 
-    @Schema(description = "프로필 사진 URL", example = "url", nullable = true)
+    @Schema(description = "프로필 사진 URL(다른 사람 기록일 때)", example = "url", nullable = true)
     String profileImageUrl();
 
-    @Schema(description = "닉네임", example = "위즈", nullable = true)
+    @Schema(description = "닉네임(다른 사람 기록일 때)", example = "위즈", nullable = true)
     String nickname();
 
-    @Schema(description = "리그 참여 난이도", example = "주황", nullable = true)
+    @Schema(description = "리그 참여 난이도(다른 사람 기록일 때)", example = "주황", nullable = true)
     String difficulty();
 
-    @Schema(description = "리그 순위", example = "17", nullable = true)
+    @Schema(description = "리그 순위(다른 사람 기록일 때)", example = "17", nullable = true)
     Integer rank();
 }

--- a/src/main/java/clpetition/backend/record/docs/dto/response/GetRecordIdResponseSchema.java
+++ b/src/main/java/clpetition/backend/record/docs/dto/response/GetRecordIdResponseSchema.java
@@ -8,7 +8,7 @@ import java.util.List;
 public interface GetRecordIdResponseSchema {
 
     @Schema(description = "등반 기록 ID", example = "3")
-    Long getRecordId();
+    Long recordId();
 
     @Schema(description = "첨부 이미지 URL 목록", example = """
                                                         [
@@ -16,5 +16,5 @@ public interface GetRecordIdResponseSchema {
                                                             "url2"
                                                         ]
                                                         """)
-    List<String> getImageUrls();
+    List<String> imageUrls();
 }

--- a/src/main/java/clpetition/backend/record/dto/response/GetRecordDetailsResponse.java
+++ b/src/main/java/clpetition/backend/record/dto/response/GetRecordDetailsResponse.java
@@ -2,36 +2,29 @@ package clpetition.backend.record.dto.response;
 
 import clpetition.backend.gym.dto.response.GetGymDetailsResponse;
 import clpetition.backend.record.docs.dto.response.GetRecordDetailsResponseSchema;
-import clpetition.backend.record.domain.Difficulties;
 import lombok.Builder;
-import lombok.Getter;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
-@Getter
 @Builder
-public class GetRecordDetailsResponse implements GetRecordDetailsResponseSchema {
-    private Long recordId;
-
-    private GetGymDetailsResponse gym;
-
-    private LocalDate date;
-
-    private Integer weekday;
-
-    private Map<String, Integer> difficulties;
-
-    private String memo;
-
-    private LocalTime exerciseTime;
-
-    private Integer satisfaction;
-
-    private Boolean isPrivate;
-
-    private List<String> imageUrls;
+public record GetRecordDetailsResponse(
+        Long recordId,
+        GetGymDetailsResponse gym,
+        LocalDate date,
+        Integer weekday,
+        Map<String, Integer> difficulties,
+        String memo,
+        LocalTime exerciseTime,
+        Integer satisfaction,
+        Boolean isPrivate,
+        List<String> imageUrls,
+        Long memberId,
+        String profileImageUrl,
+        String nickname,
+        String difficulty,
+        Integer rank
+) implements GetRecordDetailsResponseSchema {
 }

--- a/src/main/java/clpetition/backend/record/dto/response/GetRecordIdResponse.java
+++ b/src/main/java/clpetition/backend/record/dto/response/GetRecordIdResponse.java
@@ -1,18 +1,13 @@
 package clpetition.backend.record.dto.response;
 
 import clpetition.backend.record.docs.dto.response.GetRecordIdResponseSchema;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Builder
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-public class GetRecordIdResponse implements GetRecordIdResponseSchema {
-    private Long recordId;
-    private List<String> imageUrls;
+public record GetRecordIdResponse(
+        Long recordId,
+        List<String> imageUrls
+) implements GetRecordIdResponseSchema {
 }

--- a/src/main/java/clpetition/backend/record/repository/RecordQueryRepository.java
+++ b/src/main/java/clpetition/backend/record/repository/RecordQueryRepository.java
@@ -18,5 +18,5 @@ public interface RecordQueryRepository {
     List<Record> findRecordsPerMonth(Member member, YearMonth yearMonth);
     List<GetRelatedRecordResponse> findRelatedRecord(Gym gym);
     GetMainHistoryResponse findMainHistory(Member member, YearMonth yearMonth);
-    GetRecordHistoryPageResponse findRecordHistory(Member member, Long lastRecordId);
+    GetRecordHistoryPageResponse findRecordHistory(Member member, Long lastRecordId, boolean isMyself);
 }

--- a/src/main/java/clpetition/backend/record/repository/RecordQueryRepositoryImpl.java
+++ b/src/main/java/clpetition/backend/record/repository/RecordQueryRepositoryImpl.java
@@ -129,7 +129,8 @@ public class RecordQueryRepositoryImpl implements RecordQueryRepository {
                 .selectFrom(record)
                 .where(
                         record.gym.eq(gym),
-                        record.images.isNotEmpty()
+                        record.images.isNotEmpty(),
+                        record.isPrivate.eq(false)
                 )
                 .orderBy(record.date.desc())
                 .limit(RELATED_RECORD_SIZE)
@@ -168,7 +169,7 @@ public class RecordQueryRepositoryImpl implements RecordQueryRepository {
     }
 
     @Override
-    public GetRecordHistoryPageResponse findRecordHistory(Member member, Long lastRecordId) {
+    public GetRecordHistoryPageResponse findRecordHistory(Member member, Long lastRecordId, boolean isMyself) {
         LocalDate lastRecordDate = jpaQueryFactory
                 .select(record.date)
                 .from(record)
@@ -195,13 +196,12 @@ public class RecordQueryRepositoryImpl implements RecordQueryRepository {
                         record.member.eq(member),
                         lastRecordId != null ?
                                 (record.date.lt(lastRecordDate)
-                                        .or(record.date.eq(lastRecordDate).and(record.id.lt(lastRecordId)))) : null
+                                        .or(record.date.eq(lastRecordDate).and(record.id.lt(lastRecordId)))) : null,
+                        isMyself ? null : record.isPrivate.eq(false)
                 )
                 .orderBy(record.date.desc(), record.id.desc())
                 .limit(PAGE_SIZE + 1)
                 .fetch();
-
-
 
         boolean hasNext = results.size() > PAGE_SIZE;
         if (hasNext)

--- a/src/main/java/clpetition/backend/record/service/RecordService.java
+++ b/src/main/java/clpetition/backend/record/service/RecordService.java
@@ -67,12 +67,14 @@ public class RecordService {
      * 기록 상세조회
      * */
     @Transactional(readOnly = true)
-    public GetRecordDetailsResponse getRecordDetails(Long recordId) {
+    public GetRecordDetailsResponse getRecordDetails(Member member, Long recordId) {
         Record record = getRecordById(recordId);
         Hibernate.initialize(record.getImages());
-        Member member = record.getMember();
-        Map<String, Object> leagueBrief = leagueService.getLeagueBrief(member);
-        return toGetRecordDetailsResponseOthers(record, null, member, leagueBrief);
+        Member recordMember = record.getMember();
+        if (member.getId().equals(recordMember.getId()))
+            return toGetRecordDetailsResponse(record, null);
+        Map<String, Object> leagueBrief = leagueService.getLeagueBrief(recordMember);
+        return toGetRecordDetailsResponseOthers(record, null, recordMember, leagueBrief);
     }
 
     /**

--- a/src/main/java/clpetition/backend/record/service/RecordService.java
+++ b/src/main/java/clpetition/backend/record/service/RecordService.java
@@ -71,8 +71,13 @@ public class RecordService {
         Record record = getRecordById(recordId);
         Hibernate.initialize(record.getImages());
         Member recordMember = record.getMember();
+        // 본인 기록 조회
         if (member.getId().equals(recordMember.getId()))
             return toGetRecordDetailsResponse(record, null);
+        // 타인 기록 조회
+        if (record.getIsPrivate())
+            throw new BaseException(BaseResponseStatus.RECORD_NOT_FOUND_ERROR);
+
         Map<String, Object> leagueBrief = leagueService.getLeagueBrief(recordMember);
         return toGetRecordDetailsResponseOthers(record, null, recordMember, leagueBrief);
     }

--- a/src/main/java/clpetition/backend/record/service/RecordService.java
+++ b/src/main/java/clpetition/backend/record/service/RecordService.java
@@ -7,6 +7,7 @@ import clpetition.backend.gym.domain.Gym;
 import clpetition.backend.gym.service.FavoriteGymService;
 import clpetition.backend.gym.service.GymService;
 import clpetition.backend.gym.service.VisitsGymService;
+import clpetition.backend.league.service.LeagueService;
 import clpetition.backend.member.domain.Member;
 import clpetition.backend.member.dto.response.GetRecordHistoryPageResponse;
 import clpetition.backend.record.domain.Difficulties;
@@ -28,6 +29,8 @@ import java.time.LocalTime;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -39,6 +42,7 @@ public class RecordService {
     private final VisitsGymService visitsGymService;
     private final FavoriteGymService favoriteGymService;
     private final FileService fileService;
+    private final LeagueService leagueService;
     private final RecordRepository recordRepository;
     private final RecordImagesRepository recordImagesRepository;
     private final DifficultiesRepository difficultiesRepository;
@@ -63,10 +67,12 @@ public class RecordService {
      * 기록 상세조회
      * */
     @Transactional(readOnly = true)
-    public GetRecordDetailsResponse getRecordDetails(Member member, Long recordId) {
-        Record record = getRecordWithValidation(member, recordId);
+    public GetRecordDetailsResponse getRecordDetails(Long recordId) {
+        Record record = getRecordById(recordId);
         Hibernate.initialize(record.getImages());
-        return toGetRecordDetailsResponse(record, null);
+        Member member = record.getMember();
+        Map<String, Object> leagueBrief = leagueService.getLeagueBrief(member);
+        return toGetRecordDetailsResponseOthers(record, null, member, leagueBrief);
     }
 
     /**
@@ -151,8 +157,8 @@ public class RecordService {
     /**
      * 사용자의 등반기록 최신순으로 가져오기
      * */
-    public GetRecordHistoryPageResponse getRecordHistory(Member member, Long lastRecordId) {
-        return findRecordHistory(member, lastRecordId);
+    public GetRecordHistoryPageResponse getRecordHistory(Member member, Long lastRecordId, boolean isMyself) {
+        return findRecordHistory(member, lastRecordId, isMyself);
     }
 
     /**
@@ -203,7 +209,7 @@ public class RecordService {
     }
 
     /**
-     * 기록 상세조회 to dto
+     * 기록 상세조회 to dto (myself)
      * */
     private GetRecordDetailsResponse toGetRecordDetailsResponse(Record record, String shortName) {
         return GetRecordDetailsResponse.builder()
@@ -221,7 +227,39 @@ public class RecordService {
     }
 
     /**
-     * (RUD) 기록 가져오기
+     * 기록 상세조회 to dto (others)
+     * */
+    private GetRecordDetailsResponse toGetRecordDetailsResponseOthers(Record record, String shortName, Member member, Map<String, Object> leagueBrief) {
+        return GetRecordDetailsResponse.builder()
+                .recordId(record.getId())
+                .gym(gymService.getGymDetails(record.getGym(), shortName))
+                .date(record.getDate())
+                .weekday(record.getDate().getDayOfWeek().getValue())
+                .difficulties(Difficulties.convertToDifficultiesMap(record.getDifficulties()))
+                .memo(record.getMemo())
+                .exerciseTime(record.getExerciseTime())
+                .satisfaction(record.getSatisfaction())
+                .isPrivate(record.getIsPrivate())
+                .imageUrls(Record.convertToImageUrls(record.getImages()))
+                .memberId(member.getId())
+                .profileImageUrl(member.getProfileImage())
+                .nickname(member.getNickname())
+                .difficulty(!leagueBrief.get("difficulty").equals(Optional.empty()) ? leagueBrief.get("difficulty").toString() : null)
+                .rank(!leagueBrief.get("rank").equals(Optional.empty()) ? Integer.parseInt(leagueBrief.get("rank").toString()) : null)
+                .build();
+    }
+
+    /**
+     * (R) 기록 가져오기
+     * 1. 요청 기록 존재여부 확인
+     * */
+    private Record getRecordById(Long recordId) {
+        return recordRepository.findById(recordId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.RECORD_NOT_FOUND_ERROR));
+    }
+
+    /**
+     * (UD) 기록 가져오기
      * 1. 요청 기록 존재여부 확인
      * 2. 요청 사용자와 요청 기록의 소유자 동일인인지 확인
      * */
@@ -316,8 +354,8 @@ public class RecordService {
     /**
      * (R) 사용자의 등반기록 최신순으로 가져오기
      * */
-    private GetRecordHistoryPageResponse findRecordHistory(Member member, Long lastRecordId) {
-        return recordRepository.findRecordHistory(member, lastRecordId);
+    private GetRecordHistoryPageResponse findRecordHistory(Member member, Long lastRecordId, boolean isMyself) {
+        return recordRepository.findRecordHistory(member, lastRecordId, isMyself);
     }
 
     /**

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -8,7 +8,7 @@ spring:
     database-platform: org.hibernate.dialect.MySQLDialect
     open-in-view: false
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         show_sql: false


### PR DESCRIPTION
## Summary 📌
#32 
## Describe your changes 📝
- 프로필 조회 API에 이달의리그 관련 기록 응답 추가
- (GET /record/{recordId} API) 다른 사람 기록 조회 시 다른 사람의 정보 및 이달의리그 관련 기록 응답 추가
- +다른 사람 기록 조회가 가능하도록 기존의 Record API 수정
- +다른 사람 기록은 public 상태만 조회가 가능하도록 로직 추가
- 홈 화면 이달의리그 api
---
- 이달의리그에서 기록이 0인 사용자가 반환되지 않는 문제 해결
- 일부 리팩토링 진행
## Check list ✅
- [x] I write PR according to the form
- [x] All tests are passed
- [x] Program works normally
- [x] I set proper PR labels
- [x] I remove any redundant codes

## Opinions 🗣️

## Issue numbers and link 🚪
Closes #32 