### PR TITLE
Release v0.5.7

### DIFF
--- a/src/main/java/clpetition/backend/global/infra/docs/SwaggerConfig.java
+++ b/src/main/java/clpetition/backend/global/infra/docs/SwaggerConfig.java
@@ -18,7 +18,7 @@ import java.util.Arrays;
         info = @Info(
                 title = "Clpetition API Docs",
                 description = "클피티션 API 명세서",
-                version = "v0.5.6"
+                version = "v0.5.7"
         )
 )
 @Configuration

--- a/src/main/java/clpetition/backend/league/controller/LeagueController.java
+++ b/src/main/java/clpetition/backend/league/controller/LeagueController.java
@@ -9,6 +9,7 @@ import clpetition.backend.league.docs.GetLeagueRankMemberApiDocs;
 import clpetition.backend.league.docs.GetLeagueRankTopFiftyApiDocs;
 import clpetition.backend.league.dto.response.GetLeagueRankMemberResponse;
 import clpetition.backend.league.dto.response.GetLeagueRankResponse;
+import clpetition.backend.league.dto.response.GetRankResponse;
 import clpetition.backend.league.service.LeagueService;
 import clpetition.backend.member.domain.Member;
 import lombok.RequiredArgsConstructor;
@@ -33,21 +34,19 @@ public class LeagueController implements
     private final LeagueService leagueService;
 
     @PostMapping("")
-    public ResponseEntity<BaseResponse<Void>> addLeague(
+    public ResponseEntity<BaseResponse<GetRankResponse>> addLeague(
             @FindMember Member member,
             @RequestParam(value = "difficulty") String difficulty
     ) {
-        leagueService.addLeague(member, difficulty);
-        return BaseResponse.toResponseEntityContainsStatus(BaseResponseStatus.SUCCESS);
+        return BaseResponse.toResponseEntityContainsResult(leagueService.addLeague(member, difficulty));
     }
 
     @PutMapping("")
-    public ResponseEntity<BaseResponse<Void>> changeLeague(
+    public ResponseEntity<BaseResponse<GetRankResponse>> changeLeague(
             @FindMember Member member,
             @RequestParam(value = "difficulty") String difficulty
     ) {
-        leagueService.changeLeague(member, difficulty);
-        return BaseResponse.toResponseEntityContainsStatus(BaseResponseStatus.SUCCESS);
+        return BaseResponse.toResponseEntityContainsResult(leagueService.changeLeague(member, difficulty));
     }
 
     @GetMapping("/top")

--- a/src/main/java/clpetition/backend/league/docs/AddLeagueApiDocs.java
+++ b/src/main/java/clpetition/backend/league/docs/AddLeagueApiDocs.java
@@ -2,6 +2,7 @@ package clpetition.backend.league.docs;
 
 import clpetition.backend.global.annotation.FindMember;
 import clpetition.backend.global.response.BaseResponse;
+import clpetition.backend.league.dto.response.GetRankResponse;
 import clpetition.backend.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -41,7 +42,7 @@ public interface AddLeagueApiDocs {
                     ),
             }
     )
-    ResponseEntity<BaseResponse<Void>> addLeague(
+    ResponseEntity<BaseResponse<GetRankResponse>> addLeague(
             @Parameter(hidden = true)
             @FindMember Member member,
 

--- a/src/main/java/clpetition/backend/league/docs/ChangeLeagueApiDocs.java
+++ b/src/main/java/clpetition/backend/league/docs/ChangeLeagueApiDocs.java
@@ -2,6 +2,7 @@ package clpetition.backend.league.docs;
 
 import clpetition.backend.global.annotation.FindMember;
 import clpetition.backend.global.response.BaseResponse;
+import clpetition.backend.league.dto.response.GetRankResponse;
 import clpetition.backend.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -20,7 +21,7 @@ public interface ChangeLeagueApiDocs {
                     @ApiResponse(responseCode = "200", description = "🟢 정상"),
             }
     )
-    ResponseEntity<BaseResponse<Void>> changeLeague(
+    ResponseEntity<BaseResponse<GetRankResponse>> changeLeague(
             @Parameter(hidden = true)
             @FindMember Member member,
 

--- a/src/main/java/clpetition/backend/league/docs/dto/response/GetRankResponseSchema.java
+++ b/src/main/java/clpetition/backend/league/docs/dto/response/GetRankResponseSchema.java
@@ -1,0 +1,10 @@
+package clpetition.backend.league.docs.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "이달의리그 추가, 변경 시 내 순위 조회 응답")
+public interface GetRankResponseSchema {
+
+    @Schema(description = "순위, Integer가 아닌 String임을 주의", example = "1")
+    String rank();
+}

--- a/src/main/java/clpetition/backend/league/dto/response/GetRankResponse.java
+++ b/src/main/java/clpetition/backend/league/dto/response/GetRankResponse.java
@@ -1,0 +1,10 @@
+package clpetition.backend.league.dto.response;
+
+import clpetition.backend.league.docs.dto.response.GetRankResponseSchema;
+import lombok.Builder;
+
+@Builder
+public record GetRankResponse(
+        String rank
+) implements GetRankResponseSchema {
+}

--- a/src/main/java/clpetition/backend/league/repository/LeagueQueryRepositoryImpl.java
+++ b/src/main/java/clpetition/backend/league/repository/LeagueQueryRepositoryImpl.java
@@ -87,6 +87,8 @@ public class LeagueQueryRepositoryImpl implements LeagueQueryRepository {
                     rank = String.valueOf(i + 1);
                 }
             }
+            if (totalSend == 0)
+                rank = "-";
 
             getLeagueRankResponseList.add(
                     GetLeagueRankResponse.builder()
@@ -145,6 +147,8 @@ public class LeagueQueryRepositoryImpl implements LeagueQueryRepository {
                     rank = String.valueOf(i + 1);
                 }
             }
+            if (Optional.ofNullable(result.get(totalValue)).orElse(0) == 0)
+                rank = "-";
             rankList.add(rank);
 
             // member 찾기 위한 작업
@@ -155,14 +159,10 @@ public class LeagueQueryRepositoryImpl implements LeagueQueryRepository {
         if (targetIndex == -1)
             throw new BaseException(BaseResponseStatus.LEAGUE_MEMBER_NOT_FOUND_ERROR);
 
-        // member 앞뒤 +25(예외 포함)가 되도록 범위 지정
+        // member 앞뒤 +25가 되도록 범위 지정
         int startIndex, endIndex;
         startIndex = Math.max(0, targetIndex - 25);
-        switch (targetIndex) {
-            case 0 -> endIndex = Math.min(results.size(), targetIndex + 28);
-            case 1 -> endIndex = Math.min(results.size(), targetIndex + 27);
-            default -> endIndex = Math.min(results.size(), targetIndex + 26);
-        }
+        endIndex = Math.min(results.size(), targetIndex + 26);
 
         List<GetLeagueRankResponse> getLeagueRankResponseList = new ArrayList<>();
 
@@ -232,6 +232,8 @@ public class LeagueQueryRepositoryImpl implements LeagueQueryRepository {
                     rank = String.valueOf(i + 1);
                 }
             }
+            if (Optional.ofNullable(result.get(totalValue)).orElse(0) == 0)
+                rank = "-";
             rankList.add(rank);
 
             // member 찾기 위한 작업
@@ -272,6 +274,8 @@ public class LeagueQueryRepositoryImpl implements LeagueQueryRepository {
                     rank = String.valueOf(i + 1);
                 }
             }
+            if (Optional.ofNullable(result.get(totalValue)).orElse(0) == 0)
+                rank = "-";
             rankList.add(rank);
 
             // member 찾기 위한 작업

--- a/src/main/java/clpetition/backend/league/service/LeagueService.java
+++ b/src/main/java/clpetition/backend/league/service/LeagueService.java
@@ -7,6 +7,7 @@ import clpetition.backend.league.domain.League;
 import clpetition.backend.league.dto.response.GetLeagueRankMemberResponse;
 import clpetition.backend.league.dto.response.GetLeagueRankResponse;
 import clpetition.backend.league.dto.response.GetMainLeagueResponse;
+import clpetition.backend.league.dto.response.GetRankResponse;
 import clpetition.backend.league.repository.LeagueRepository;
 import clpetition.backend.member.domain.Member;
 import lombok.RequiredArgsConstructor;
@@ -29,17 +30,21 @@ public class LeagueService {
     /**
      * 리그 추가
      * */
-    public void addLeague(Member member, String difficulty) {
+    public GetRankResponse addLeague(Member member, String difficulty) {
         isAlreadyExist(member);
         toLeague(member, difficulty);
+        String rank = getLeagueRank(member, SEASON, Difficulty.findByKey(difficulty));
+        return toGetRankResponse(rank);
     }
 
     /**
      * 리그 수정(삭제 후 저장)
      * */
-    public void changeLeague(Member member, String difficulty) {
+    public GetRankResponse changeLeague(Member member, String difficulty) {
         deleteLeague(member);
         toLeague(member, difficulty);
+        String rank = getLeagueRank(member, SEASON, Difficulty.findByKey(difficulty));
+        return toGetRankResponse(rank);
     }
 
     /**
@@ -121,6 +126,15 @@ public class LeagueService {
     private void isAlreadyExist(Member member) {
         if (leagueRepository.existsByMemberAndSeason(member, SEASON))
             throw new BaseException(BaseResponseStatus.LEAGUE_ALREADY_REGISTERED_ERROR);
+    }
+
+    /**
+     * 리그 추가, 수정 후 순위 반환 to dto
+     * */
+    private GetRankResponse toGetRankResponse(String rank) {
+        return GetRankResponse.builder()
+                .rank(rank)
+                .build();
     }
 
     /**


### PR DESCRIPTION
## Summary 📌
- #49 
## Describe your changes 📝
- totalSend == 0 일 때 순위를 부여하지 않고 "-" 형태로 부여 (리그에는 참여했으나, 아직 완등 수가 없는 case)
- 나와 주변 순위 제공 시 앞뒤 +25까지만 주는 것으로 범위 고정
- 리그 참여 및 변경 시 응답으로 참여한 리그의 내 순위 제공
## Check list ✅
- [ ] I write PR according to the form
- [ ] All tests are passed
- [ ] Program works normally
- [ ] I set proper PR labels
- [ ] I remove any redundant codes

## Opinions 🗣️

## Issue numbers and link 🚪
Closes #{issue number}